### PR TITLE
Added `#pragma once`

### DIFF
--- a/defer.h
+++ b/defer.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef DEFER_H
 #define DEFER_H
 


### PR DESCRIPTION
There should be a `#pragma once` in every header file. This helps the C/C++ linker and is also a convention.